### PR TITLE
calculateFutureRewards fix

### DIFF
--- a/src/utils/calculateFutureRewardsAmount.ts
+++ b/src/utils/calculateFutureRewardsAmount.ts
@@ -206,9 +206,7 @@ export const calculateFutureRewardsAmount = async (
     currentAvailableRewardsForPool.toString()
   );
   const rewardsPerSession = new BN("136986000000000000000000");
-  const sessionsToPass = futureTimeBlockNumber
-    .sub(blockNumber)
-    .div(new BN(1200));
+  const sessionsToPass = new BN(futureTimeBlockNumber).div(new BN(1200));
   const numberOfPromotedPools =
     await api.query.issuance.promotedPoolsRewards.entries();
 


### PR DESCRIPTION
replaced 
const sessionsToPass = futureTimeBlockNumber
    .sub(blockNumber)
    .div(new BN(1200));
    
  where this num should be sessions that will pass in 30 days. futureTimeBlockNumber(fn arg, 216000) - currentBlockNumber = negative number from block 216000 and later.
  
  with
  const sessionsToPass = new BN(futureTimeBlockNumber).div(new BN(1200));
  while keeping futureTimeBlockNumber as arg, if we want to change it depending on block prod speed in the future