### PR TITLE
chore(release): 1.19.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.19.0](https://github.com/mangata-finance/mangata-sdk/compare/v1.18.2...v1.19.0) (2023-04-05)
+
+
+### Features
+
+* add method fee for statemine ([00eb074](https://github.com/mangata-finance/mangata-sdk/commit/00eb07430213bdb61477e0719e900f3dac3e56d8))
+
 ## [1.18.2](https://github.com/mangata-finance/mangata-sdk/compare/v1.18.1...v1.18.2) (2023-04-04)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangata-finance/sdk",
-  "version": "1.18.2",
+  "version": "1.19.0",
   "description": "SDK for communication with Mangata node",
   "main": "./index.js",
   "module": "./index.mjs",


### PR DESCRIPTION
# [1.19.0](https://github.com/mangata-finance/mangata-sdk/compare/v1.18.2...v1.19.0) (2023-04-05)

### Features

* add method fee for statemine ([00eb074](https://github.com/mangata-finance/mangata-sdk/commit/00eb07430213bdb61477e0719e900f3dac3e56d8))