### PR TITLE
chore(release): 1.21.7 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.21.7](https://github.com/mangata-finance/mangata-sdk/compare/v1.21.6...v1.21.7) (2023-07-14)
+
+
+### Bug Fixes
+
+* update proofsize for withdraw ([4dfc4a2](https://github.com/mangata-finance/mangata-sdk/commit/4dfc4a2e11e16e7b1958c1d6ff59a919ea79fc22))
+
 ## [1.21.6](https://github.com/mangata-finance/mangata-sdk/compare/v1.21.5...v1.21.6) (2023-07-14)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mangata-finance/sdk",
-  "version": "1.21.6",
+  "version": "1.21.7",
   "description": "SDK for communication with Mangata node",
   "main": "./index.js",
   "module": "./index.mjs",


### PR DESCRIPTION
## [1.21.7](https://github.com/mangata-finance/mangata-sdk/compare/v1.21.6...v1.21.7) (2023-07-14)

### Bug Fixes

* update proofsize for withdraw ([4dfc4a2](https://github.com/mangata-finance/mangata-sdk/commit/4dfc4a2e11e16e7b1958c1d6ff59a919ea79fc22))